### PR TITLE
Update GitHub release automation

### DIFF
--- a/.github/workflows/propose_release.yml
+++ b/.github/workflows/propose_release.yml
@@ -1,17 +1,25 @@
 name: Propose Stable Release
 on:
   workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        description: Release Type
+        options:
+          - patch
+          - minor
+          - major
 jobs:
   update_version:
-    uses: neongeckocom/.github/.github/workflows/propose_dated_release.yml@master
+    uses: neongeckocom/.github/.github/workflows/propose_semver_release.yml@master
     with:
       branch: dev
-      update_changelog: true
-      # Changelog automation fails with this large repo
+      release_type: ${{ inputs.release_type }}
+      update_changelog: True
       version_file: "neon_minerva/version.py"
-
   pull_changes:
     uses: neongeckocom/.github/.github/workflows/pull_master.yml@master
+    needs: update_version
     with:
       pr_reviewer: neonreviewers
       pr_assignee: ${{ github.actor }}


### PR DESCRIPTION
# Description
Fix `propose_release` automation to use semver release instead of dated release

# Issues
Fix for #6

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->