### PR TITLE
Add compat. reference for `bus.emitter`

### DIFF
--- a/neon_minerva/tests/skill_unit_test_base.py
+++ b/neon_minerva/tests/skill_unit_test_base.py
@@ -47,6 +47,9 @@ class SkillTestCase(unittest.TestCase):
 
     # Define static parameters
     bus = FakeBus()
+    # Patching FakeBus compat. with MessageBusClient
+    bus.emitter = bus.ee
+
     bus.run_forever()
     test_skill_id = 'test_skill.test'
 


### PR DESCRIPTION
# Description
Define `FakeBus.emitter` to match `MessageBusClient` for test compat.

# Issues
Test failure noted https://github.com/NeonGeckoCom/skill-core_ready/actions/runs/6910260380/job/18803077565

# Other Notes
Validated https://github.com/NeonGeckoCom/skill-core_ready/actions/runs/6910292962/job/18803171123?pr=1