### PR TITLE
Fix bug causing dialog tests to pass when translations are missing

### DIFF
--- a/neon_minerva/skill.py
+++ b/neon_minerva/skill.py
@@ -40,11 +40,14 @@ def get_skill_object(skill_entrypoint: str, bus: FakeBus,
     @param skill_entrypoint: Skill plugin entrypoint or directory path
     @param bus: FakeBus instance to bind to skill for testing
     @param skill_id: skill_id to initialize skill with
+    @param config_patch: Configuration update to apply
     @returns: Initialized skill object
     """
     if config_patch:
-        from ovos_config.config import update_mycroft_config
-        update_mycroft_config(config_patch)
+        from ovos_config.config import update_mycroft_config, Configuration
+        user_config = update_mycroft_config(config_patch)
+        if user_config not in Configuration.xdg_configs:
+            Configuration.xdg_configs.append(user_config)
     if isdir(skill_entrypoint):
         LOG.info(f"Loading local skill: {skill_entrypoint}")
         from ovos_workshop.skill_launcher import SkillLoader

--- a/neon_minerva/tests/test_skill_resources.py
+++ b/neon_minerva/tests/test_skill_resources.py
@@ -27,7 +27,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import os
 import json
 
 from os import getenv
@@ -84,7 +83,8 @@ class TestSkillResources(unittest.TestCase):
         self.assertEqual(self.skill.skill_id, self.test_skill_id)
         self.assertEqual(set([self.skill._core_lang] +
                              self.skill._secondary_langs),
-                         set(self.supported_languages))
+                         set(self.supported_languages),
+                         f"expected={self.supported_languages}")
 
     def test_intent_registration(self):
         registered_adapt = list()
@@ -137,8 +137,9 @@ class TestSkillResources(unittest.TestCase):
 
     def test_dialog_files(self):
         for lang in self.supported_languages:
+            dialogs = self.skill._lang_resources[lang].dialog_renderer.templates
             for dialog in self.dialog:
-                file = self.skill.find_resource(f"{dialog}.dialog", "dialog",
-                                                lang)
-                self.assertIsInstance(file, str, f"{dialog} in {self.dialog}")
-                self.assertTrue(os.path.isfile(file), dialog)
+                self.assertIn(dialog, dialogs.keys(),
+                              f"lang={lang}")
+
+    # TODO: Consider adding tests for resource file existence


### PR DESCRIPTION
# Description
Update to resolve local test config bug
Refactor dialog tests to reference skill object instead of files

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->