### PR TITLE
Support testing a skill with no dialog resources

### DIFF
--- a/neon_minerva/tests/test_skill_resources.py
+++ b/neon_minerva/tests/test_skill_resources.py
@@ -137,6 +137,9 @@ class TestSkillResources(unittest.TestCase):
 
     def test_dialog_files(self):
         for lang in self.supported_languages:
+            if not self.dialog:
+                self.assertIsNone(self.skill._lang_resources[lang].dialog_renderer)
+                return
             dialogs = self.skill._lang_resources[lang].dialog_renderer.templates
             for dialog in self.dialog:
                 self.assertIn(dialog, dialogs.keys(),


### PR DESCRIPTION
# Description
Adds handling for empty dialog resources

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Issue noted in https://github.com/NeonGeckoCom/skill-spelling/pull/26