### PR TITLE
Update Common Query and Intent Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ The following top-level sections can be added to intent test configuration:
   to expected: `callback_data` (list keys or dict data), `min_confidence`, and
   `max_confidence`
 - `common play`: TBD
-
+- `ready event`: Optional event name to wait for before starting tests. For example,
+  a skill may set `_update_event` after doing some long-running process at initialization;
+  configuring `ready event: _update_event` means intent tests will not start until
+  the skill has updated and is ready to handle inputs.
 ## Advanced Usage
 In addition to convenient CLI methods, this package also provides test cases that
 may be extended.


### PR DESCRIPTION
# Description
Add a `ready event` config option for intent tests to allow skills to report ready for intent handling
Add default response to `ask_yesno` to prevent infinite waiting for a response
Refactor `test_common_query` for readability
Add more output to failure cases
Handle new Messages containing `answer` fields

# Issues
Behavior change noted in https://github.com/NeonGeckoCom/skill-caffeinewiz/pull/78

# Other Notes
This is a breaking change since older skills will not include the `answer` field