### PR TITLE
Implement RabbitMQ test fixture

### DIFF
--- a/neon_minerva/__init__.py
+++ b/neon_minerva/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/chatbots/__init__.py
+++ b/neon_minerva/chatbots/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 #
-# Copyright 2008-2023 Neongecko.com Inc. | All Rights Reserved
+# Copyright 2008-2025 Neongecko.com Inc. | All Rights Reserved
 #
 # Notice of License - Duplicating this Notice of License near the start of any file containing
 # a derivative of this software is a condition of license for this software.

--- a/neon_minerva/chatbots/test_constants.py
+++ b/neon_minerva/chatbots/test_constants.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 #
-# Copyright 2008-2023 Neongecko.com Inc. | All Rights Reserved
+# Copyright 2008-2025 Neongecko.com Inc. | All Rights Reserved
 #
 # Notice of License - Duplicating this Notice of License near the start of any file containing
 # a derivative of this software is a condition of license for this software.

--- a/neon_minerva/chatbots/util.py
+++ b/neon_minerva/chatbots/util.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 #
-# Copyright 2008-2023 Neongecko.com Inc. | All Rights Reserved
+# Copyright 2008-2025 Neongecko.com Inc. | All Rights Reserved
 #
 # Notice of License - Duplicating this Notice of License near the start of any file containing
 # a derivative of this software is a condition of license for this software.

--- a/neon_minerva/cli.py
+++ b/neon_minerva/cli.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/exceptions.py
+++ b/neon_minerva/exceptions.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/integration/__init__.py
+++ b/neon_minerva/integration/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -73,9 +73,10 @@ def rmq_instance(request, tmp_path_factory):
     # Init RMQ config
     rmq_username = environ.get("TEST_RMQ_USERNAME", "test_llm_user")
     rmq_password = environ.get("TEST_RMQ_PASSWORD", "test_llm_password")
-    rmq_vhost = environ.get("TEST_RMQ_VHOST", "/test")
+    rmq_vhosts = environ.get("TEST_RMQ_VHOSTS", "/test")
     rabbit_executor.rabbitctl_output("add_user", rmq_username, rmq_password)
-    rabbit_executor.rabbitctl_output("add_vhost", rmq_vhost)
-    rabbit_executor.rabbitctl_output("set_permissions", "-p", rmq_vhost,
-                                     rmq_username, ".*", ".*", ".*")
+    for vhost in rmq_vhosts.split(","):
+        rabbit_executor.rabbitctl_output("add_vhost", vhost)
+        rabbit_executor.rabbitctl_output("set_permissions", "-p", vhost,
+                                         rmq_username, ".*", ".*", ".*")
     request.cls.rmq_instance = rabbit_executor

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -1,0 +1,81 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+
+from os import environ
+from port_for import get_port
+from pytest_rabbitmq.factories.executor import RabbitMqExecutor
+from pytest_rabbitmq.factories.process import get_config
+
+
+@pytest.fixture(scope="class")
+def rmq_instance(request, tmp_path_factory):
+    config = get_config(request)
+    rabbit_ctl = config["ctl"]
+    rabbit_server = config["server"]
+    rabbit_host = "127.0.0.1"
+    rabbit_port = get_port(config["port"])
+    rabbit_distribution_port = get_port(
+        config["distribution_port"], [rabbit_port]
+    )
+    assert rabbit_distribution_port
+    assert (
+            rabbit_distribution_port != rabbit_port
+    ), "rabbit_port and distribution_port can not be the same!"
+
+    tmpdir = tmp_path_factory.mktemp(f"pytest-rabbitmq-{request.fixturename}")
+
+    rabbit_plugin_path = config["plugindir"]
+
+    rabbit_logpath = config["logsdir"]
+
+    if not rabbit_logpath:
+        rabbit_logpath = tmpdir / "logs"
+
+    rabbit_executor = RabbitMqExecutor(
+        rabbit_server,
+        rabbit_host,
+        rabbit_port,
+        rabbit_distribution_port,
+        rabbit_ctl,
+        logpath=rabbit_logpath,
+        path=tmpdir,
+        plugin_path=rabbit_plugin_path,
+        node_name=config["node"],
+    )
+
+    rabbit_executor.start()
+
+    # Init RMQ config
+    rmq_username = environ.get("TEST_RMQ_USERNAME", "test_llm_user")
+    rmq_password = environ.get("TEST_RMQ_PASSWORD", "test_llm_password")
+    rmq_vhost = environ.get("TEST_RMQ_VHOST", "/test")
+    rabbit_executor.rabbitctl_output("add_user", rmq_username, rmq_password)
+    rabbit_executor.rabbitctl_output("add_vhost", rmq_vhost)
+    rabbit_executor.rabbitctl_output("set_permissions", "-p", rmq_vhost,
+                                     rmq_username, ".*", ".*", ".*")
+    request.cls.rmq_instance = rabbit_executor

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -71,8 +71,8 @@ def rmq_instance(request, tmp_path_factory):
     rabbit_executor.start()
 
     # Init RMQ config
-    rmq_username = environ.get("TEST_RMQ_USERNAME", "test_llm_user")
-    rmq_password = environ.get("TEST_RMQ_PASSWORD", "test_llm_password")
+    rmq_username = environ.get("TEST_RMQ_USERNAME", "test_user")
+    rmq_password = environ.get("TEST_RMQ_PASSWORD", "test_password")
     rmq_vhosts = environ.get("TEST_RMQ_VHOSTS", "/test")
     rabbit_executor.rabbitctl_output("add_user", rmq_username, rmq_password)
     for vhost in rmq_vhosts.split(","):

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2024 NeonGecko.com Inc.
+# Copyright 2008-2025 NeonGecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/integration/user_utterance.py
+++ b/neon_minerva/integration/user_utterance.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/intent_services/__init__.py
+++ b/neon_minerva/intent_services/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/intent_services/adapt.py
+++ b/neon_minerva/intent_services/adapt.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/intent_services/common_query.py
+++ b/neon_minerva/intent_services/common_query.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/intent_services/padacioso.py
+++ b/neon_minerva/intent_services/padacioso.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/intent_services/padatious.py
+++ b/neon_minerva/intent_services/padatious.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/skill.py
+++ b/neon_minerva/skill.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/tests/__init__.py
+++ b/neon_minerva/tests/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/neon_minerva/tests/chatbot_v1_test_base.py
+++ b/neon_minerva/tests/chatbot_v1_test_base.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 #
-# Copyright 2008-2023 Neongecko.com Inc. | All Rights Reserved
+# Copyright 2008-2025 Neongecko.com Inc. | All Rights Reserved
 #
 # Notice of License - Duplicating this Notice of License near the start of any file containing
 # a derivative of this software is a condition of license for this software.

--- a/neon_minerva/tests/skill_unit_test_base.py
+++ b/neon_minerva/tests/skill_unit_test_base.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/tests/test_skill_intents.py
+++ b/neon_minerva/tests/test_skill_intents.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/tests/test_skill_resources.py
+++ b/neon_minerva/tests/test_skill_resources.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/neon_minerva/version.py
+++ b/neon_minerva/version.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License

--- a/requirements/rabbit_mq.txt
+++ b/requirements/rabbit_mq.txt
@@ -1,1 +1,1 @@
-pytest-rabbitmq
+pytest-rabbitmq~=3.0

--- a/requirements/rabbit_mq.txt
+++ b/requirements/rabbit_mq.txt
@@ -1,0 +1,1 @@
+pytest-rabbitmq

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=get_requirements("requirements.txt"),
     extras_require={"chatbots": get_requirements("chatbots.txt"),
-                    "padatious": get_requirements("padatious.txt")},
+                    "padatious": get_requirements("padatious.txt"),
+                    "rmq": get_requirements("rabbit_mq.txt")},
     entry_points={
         'console_scripts': ['minerva=neon_minerva.cli:neon_minerva_cli']
     }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2025 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License


### PR DESCRIPTION
# Description
Adds rmq_instance class decorator to manage a RabbitMQ server for testing


# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
`TEST_RMQ_USERNAME` and  `TEST_RMQ_PASSWORD` envvars should be set with a single RabbitMQ username/password that will be used to authenticate
`TEST_RMQ_VHOSTS` envvar should be set with a comma-separated list of vhosts to configure; the configured user will have full access to these vhosts