### PR TITLE
Update for ovos-core 1.x Compat.

### DIFF
--- a/neon_minerva/skill.py
+++ b/neon_minerva/skill.py
@@ -28,7 +28,7 @@ import yaml
 
 from os.path import expanduser, isfile, isdir
 from typing import Optional
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_workshop.skills.base import BaseSkill
 from ovos_utils.log import LOG
 

--- a/neon_minerva/tests/test_skill_intents.py
+++ b/neon_minerva/tests/test_skill_intents.py
@@ -33,7 +33,7 @@ from os.path import join, exists
 from unittest.mock import Mock
 
 from ovos_bus_client import Message
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
 from neon_minerva.exceptions import IntentException

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,5 +4,6 @@ ovos-utils~=0.0, >=0.0.35
 ovos-workshop~=0.0,>=0.0.15
 ovos-bus-client~=0.0
 padacioso~=0.1
+adapt-parser
 pyyaml>=5.4,<7.0
 # PyYaml 5.4 support left for ovos-core 0.0.7 compat


### PR DESCRIPTION
# Description
Update imports to resolve deprecation warnings
Add `adapt-parser` dependency removed from ovos-core extras in or around release 1.0.0

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Validated with the [date-time skill](https://github.com/NeonGeckoCom/skill-date_time/actions/runs/17085296035?pr=82)