### PR TITLE
Update CommonQuery tests to support session language handling

### DIFF
--- a/neon_minerva/intent_services/common_query.py
+++ b/neon_minerva/intent_services/common_query.py
@@ -101,6 +101,8 @@ class CommonQuery:
         """
         utt = message.data.get('utterance')
         sid = "test_session"
+        message.context.setdefault('session', {})
+        message.context['session']['session_id'] = sid
         # TODO: Why are defaults not creating new objects on init?
         query = Query(session_id=sid, query=utt, replies=[], extensions=[],
                       query_time=time.time(), timeout_time=time.time() + 1,

--- a/neon_minerva/tests/test_skill_intents.py
+++ b/neon_minerva/tests/test_skill_intents.py
@@ -174,7 +174,8 @@ class TestSkillIntentMatching(unittest.TestCase):
                     data = dict()
                 utt = utt.lower()
                 message = Message('test_utterance',
-                                  {"utterance": utt, "lang": lang})
+                                  {"utterance": utt, "lang": lang},
+                                  {"session": {"lang": lang}})
                 self.common_query_service.handle_question(message)
                 response = qa_response.call_args[0][0]
                 callback = qa_response.call_args[0][0]


### PR DESCRIPTION
# Description
Add session.lang handling to CommonQuery tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Tested with https://github.com/NeonDaniel/skill-stock/actions/runs/21378309662