### PR TITLE
Allow RMQ entrypoint without optional extras

### DIFF
--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -27,13 +27,25 @@
 import pytest
 
 from os import environ
-from port_for import get_port
-from pytest_rabbitmq.factories.executor import RabbitMqExecutor
-from pytest_rabbitmq.factories.process import get_config
+
+try:
+    from port_for import get_port
+    from pytest_rabbitmq.factories.executor import RabbitMqExecutor
+    from pytest_rabbitmq.factories.process import get_config
+    _INITIALIZED = True
+except ImportError:
+    _INITIALIZED = False
 
 
 @pytest.fixture(scope="class")
 def rmq_instance(request, tmp_path_factory):
+    """Start a RabbitMQ subprocess for the test class and stop it after."""
+
+    if not _INITIALIZED:
+        raise ModuleNotFoundError(
+            "Missing optional extra dependencies install `neon-minerva[rmq]`"
+        )
+
     config = get_config(request)
     rabbit_ctl = config["ctl"]
     rabbit_server = config["server"]


### PR DESCRIPTION
# Description
Add try/except so package is installable without optional `rmq` extras

# Issues
- Introduced in #33

# Other Notes
- Tested in https://github.com/NeonGeckoCom/skill-alerts/pull/149