### PR TITLE
Replace RMQ entrypoint

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,3 +8,33 @@ on:
 jobs:
   py_build_tests:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
+  unit_tests:
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install apt dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rabbitmq-server
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+
+      - name: Run Tests
+        run: |
+          pytest tests \
+            --junitxml=tests/test-results-${{ matrix.python-version }}.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.python-version }}
+          path: tests/test-results-${{ matrix.python-version }}.xml

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -115,6 +115,13 @@ def _stop_executor_quietly(executor):
         _kill_executor_processgroup(executor)
 
 
+def _stop_all_tracked_executors():
+    """Stop every executor we know about (best-effort, time-bounded)."""
+    for executor in list(_ACTIVE_RMQ_EXECUTORS):
+        _stop_executor_quietly(executor)
+    _ACTIVE_RMQ_EXECUTORS.clear()
+
+
 def _force_exit_on_stalled_shutdown():
     """Last-resort safety net for interpreter shutdown.
 
@@ -124,10 +131,16 @@ def _force_exit_on_stalled_shutdown():
     ``_RMQ_FORCE_EXIT_GRACE_SECONDS`` seconds. The watchdog spawns and the
     hook returns immediately so other ``atexit`` hooks (notably
     ``mirakuru.base.cleanup_subprocesses``) still get to run.
+
+    NOTE: this is only a fallback. Python runs ``atexit`` hooks *after* it
+    has joined every non-daemon thread, so if a consuming project leaves a
+    non-daemon thread alive (e.g. a pika consumer that never exited), the
+    interpreter will be stuck on that join and this hook will never fire.
+    The primary safety net lives in the ``pytest_sessionfinish`` hook
+    contributed by this module via the ``pytest11`` entry point, which runs
+    early enough that the watchdog can take effect.
     """
-    for executor in list(_ACTIVE_RMQ_EXECUTORS):
-        _stop_executor_quietly(executor)
-    _ACTIVE_RMQ_EXECUTORS.clear()
+    _stop_all_tracked_executors()
     _arm_force_exit_watchdog(_RMQ_FORCE_EXIT_GRACE_SECONDS, exit_code=0)
 
 
@@ -226,3 +239,22 @@ def rmq_instance(request, tmp_path_factory):
             _ACTIVE_RMQ_EXECUTORS.remove(rabbit_executor)
         except ValueError:
             pass
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Stop tracked executors and arm a hard-exit watchdog.
+
+    This hook fires while the interpreter is still healthy (before Python
+    starts joining non-daemon threads at shutdown), which is the only point
+    at which a daemon-thread watchdog can reliably take effect: ``atexit``
+    hooks run *after* the non-daemon thread join, so they cannot rescue a
+    process that's stuck because some consumer or pika ioloop thread never
+    exited.
+
+    Discoverable when this module is loaded as a pytest plugin via the
+    ``pytest11`` entry point declared in ``setup.py``.
+    """
+    _stop_all_tracked_executors()
+    grace = _RMQ_FORCE_EXIT_GRACE_SECONDS
+    code = int(exitstatus) if isinstance(exitstatus, int) else 0
+    _arm_force_exit_watchdog(grace, exit_code=code)

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -24,6 +24,12 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import atexit
+import os
+import sys
+import threading
+import time
+
 import pytest
 
 from os import environ
@@ -35,6 +41,71 @@ try:
     _INITIALIZED = True
 except ImportError:
     _INITIALIZED = False
+
+
+# Track every executor we hand out so that interpreter shutdown can stop
+# any that test code or another fixture forgot to release.
+_ACTIVE_RMQ_EXECUTORS: "list[RabbitMqExecutor]" = []
+
+# How long, after our atexit hook fires, we'll let the interpreter attempt
+# a normal shutdown before forcefully exiting. The Erlang VM that backs
+# RabbitMQ has been observed to ignore the signal sent by ``mirakuru``'s
+# ``__del__``/``atexit`` cleanup on GitHub-hosted runners, leaving pytest
+# blocked indefinitely after it has already reported its results. The
+# watchdog runs in a daemon thread so it can never itself prevent exit.
+_RMQ_FORCE_EXIT_GRACE_SECONDS = 30
+
+
+def _stop_executor_quietly(executor):
+    """Best-effort teardown that never raises into the test session."""
+    if executor is None:
+        return
+    try:
+        if executor.running():
+            executor.stop()
+    except Exception:
+        try:
+            executor.kill(wait=False)
+        except Exception:
+            pass
+
+
+def _force_exit_on_stalled_shutdown():
+    """Last-resort safety net for interpreter shutdown.
+
+    Stops any executors we still know about (in case a test or downstream
+    fixture leaked one) and arms a daemon-thread watchdog that ``os._exit``s
+    if the rest of the shutdown sequence does not complete in
+    ``_RMQ_FORCE_EXIT_GRACE_SECONDS`` seconds. The watchdog spawns and the
+    hook returns immediately so other ``atexit`` hooks (notably
+    ``mirakuru.base.cleanup_subprocesses``) still get to run.
+    """
+    for executor in list(_ACTIVE_RMQ_EXECUTORS):
+        _stop_executor_quietly(executor)
+    _ACTIVE_RMQ_EXECUTORS.clear()
+
+    grace = _RMQ_FORCE_EXIT_GRACE_SECONDS
+
+    def _watchdog():
+        time.sleep(grace)
+        sys.stderr.write(
+            f"\n[neon_minerva.rabbit_mq] forcing process exit after {grace}s "
+            f"grace period; normal shutdown stalled.\n"
+        )
+        sys.stderr.flush()
+        os._exit(0)
+
+    threading.Thread(
+        target=_watchdog,
+        name="neon-minerva-rmq-force-exit",
+        daemon=True,
+    ).start()
+
+
+# Register at import time so the hook is always armed when the fixture is
+# in use, regardless of whether ``neon-minerva`` is loaded as a pytest
+# plugin via entry points or simply imported by a test module.
+atexit.register(_force_exit_on_stalled_shutdown)
 
 
 @pytest.fixture(scope="class")
@@ -81,6 +152,7 @@ def rmq_instance(request, tmp_path_factory):
     )
 
     rabbit_executor.start()
+    _ACTIVE_RMQ_EXECUTORS.append(rabbit_executor)
 
     # Init RMQ config
     rmq_username = environ.get("TEST_RMQ_USERNAME", "test_user")
@@ -92,3 +164,11 @@ def rmq_instance(request, tmp_path_factory):
         rabbit_executor.rabbitctl_output("set_permissions", "-p", vhost,
                                          rmq_username, ".*", ".*", ".*")
     request.cls.rmq_instance = rabbit_executor
+    try:
+        yield rabbit_executor
+    finally:
+        _stop_executor_quietly(rabbit_executor)
+        try:
+            _ACTIVE_RMQ_EXECUTORS.remove(rabbit_executor)
+        except ValueError:
+            pass

--- a/neon_minerva/integration/rabbit_mq.py
+++ b/neon_minerva/integration/rabbit_mq.py
@@ -26,6 +26,7 @@
 
 import atexit
 import os
+import signal
 import sys
 import threading
 import time
@@ -47,27 +48,71 @@ except ImportError:
 # any that test code or another fixture forgot to release.
 _ACTIVE_RMQ_EXECUTORS: "list[RabbitMqExecutor]" = []
 
-# How long, after our atexit hook fires, we'll let the interpreter attempt
-# a normal shutdown before forcefully exiting. The Erlang VM that backs
-# RabbitMQ has been observed to ignore the signal sent by ``mirakuru``'s
-# ``__del__``/``atexit`` cleanup on GitHub-hosted runners, leaving pytest
-# blocked indefinitely after it has already reported its results. The
-# watchdog runs in a daemon thread so it can never itself prevent exit.
+# Maximum time we'll spend trying to gracefully stop a single
+# ``RabbitMqExecutor`` before falling back to a direct SIGKILL of its
+# process group.
+_RMQ_STOP_TIMEOUT_SECONDS = 10
+
+# How long, after the test session reaches teardown / interpreter shutdown,
+# we'll let the rest of the cleanup run before forcefully exiting. The
+# Erlang VM that backs RabbitMQ has been observed to ignore the signal
+# sent by ``mirakuru``'s ``stop`` / ``__del__`` / ``atexit`` cleanup on
+# GitHub-hosted runners, leaving pytest blocked after it has already
+# reported its results. The watchdog runs in a daemon thread so it can
+# never itself prevent exit.
 _RMQ_FORCE_EXIT_GRACE_SECONDS = 30
 
 
-def _stop_executor_quietly(executor):
-    """Best-effort teardown that never raises into the test session."""
-    if executor is None:
+def _kill_executor_processgroup(executor):
+    """Send SIGKILL to the executor's process group, no questions asked.
+
+    ``mirakuru`` sets ``os.setsid`` as ``preexec_fn`` for its subprocesses
+    so the spawned process is its own group leader and ``killpg`` reaches
+    every child the broker may have started. We deliberately avoid
+    ``mirakuru.SimpleExecutor.stop`` / ``kill(wait=True)`` here because
+    both call ``self.process.wait()`` which can block indefinitely if the
+    subprocess refuses to die.
+    """
+    process = getattr(executor, "process", None)
+    pid = getattr(process, "pid", None)
+    if not pid:
         return
     try:
-        if executor.running():
-            executor.stop()
-    except Exception:
+        os.killpg(pid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        pass
+
+
+def _stop_executor_quietly(executor):
+    """Best-effort, time-bounded teardown that never blocks indefinitely.
+
+    First try ``executor.stop()`` in a daemon thread so we can give up if
+    ``mirakuru`` blocks waiting for the broker to die. If that does not
+    return inside ``_RMQ_STOP_TIMEOUT_SECONDS``, fall back to a direct
+    ``killpg(SIGKILL)`` on the broker's process group and move on.
+    """
+    if executor is None:
+        return
+
+    stop_done = threading.Event()
+
+    def _do_stop():
         try:
-            executor.kill(wait=False)
+            if executor.running():
+                executor.stop()
         except Exception:
             pass
+        finally:
+            stop_done.set()
+
+    threading.Thread(
+        target=_do_stop,
+        name="neon-minerva-rmq-stop",
+        daemon=True,
+    ).start()
+
+    if not stop_done.wait(_RMQ_STOP_TIMEOUT_SECONDS):
+        _kill_executor_processgroup(executor)
 
 
 def _force_exit_on_stalled_shutdown():
@@ -83,17 +128,26 @@ def _force_exit_on_stalled_shutdown():
     for executor in list(_ACTIVE_RMQ_EXECUTORS):
         _stop_executor_quietly(executor)
     _ACTIVE_RMQ_EXECUTORS.clear()
+    _arm_force_exit_watchdog(_RMQ_FORCE_EXIT_GRACE_SECONDS, exit_code=0)
 
-    grace = _RMQ_FORCE_EXIT_GRACE_SECONDS
 
+def _arm_force_exit_watchdog(grace_seconds, exit_code=0):
+    """Spawn a daemon thread that ``os._exit``s after ``grace_seconds``.
+
+    Daemon threads are killed automatically when the main thread exits, so
+    on a healthy shutdown the watchdog never fires. It only matters when
+    the surrounding teardown code stalls -- in which case the watchdog
+    forcibly terminates the process so the surrounding job (CI step, etc.)
+    can move on instead of silently deadlocking.
+    """
     def _watchdog():
-        time.sleep(grace)
+        time.sleep(grace_seconds)
         sys.stderr.write(
-            f"\n[neon_minerva.rabbit_mq] forcing process exit after {grace}s "
-            f"grace period; normal shutdown stalled.\n"
+            f"\n[neon_minerva.rabbit_mq] forcing process exit after "
+            f"{grace_seconds}s grace period; shutdown stalled.\n"
         )
         sys.stderr.flush()
-        os._exit(0)
+        os._exit(exit_code)
 
     threading.Thread(
         target=_watchdog,

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,0 +1,2 @@
+pytest~=8.0
+pytest-rabbitmq~=3.0

--- a/setup.py
+++ b/setup.py
@@ -79,12 +79,8 @@ setuptools.setup(
                     "rmq": get_requirements("rabbit_mq.txt")},
     entry_points={
         'console_scripts': ['minerva=neon_minerva.cli:neon_minerva_cli'],
-        # Register the RabbitMQ integration module as a pytest plugin so
-        # its ``pytest_sessionfinish`` hook is discovered automatically by
-        # any project that depends on neon-minerva, even when consumers
-        # only ``import`` the fixture rather than installing as a plugin.
         'pytest11': [
-            'neon_minerva_rabbit_mq = neon_minerva.integration.rabbit_mq',
+            'neon.rabbit_mq = neon_minerva.integration.rabbit_mq',
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,13 @@ setuptools.setup(
                     "padatious": get_requirements("padatious.txt"),
                     "rmq": get_requirements("rabbit_mq.txt")},
     entry_points={
-        'console_scripts': ['minerva=neon_minerva.cli:neon_minerva_cli']
+        'console_scripts': ['minerva=neon_minerva.cli:neon_minerva_cli'],
+        # Register the RabbitMQ integration module as a pytest plugin so
+        # its ``pytest_sessionfinish`` hook is discovered automatically by
+        # any project that depends on neon-minerva, even when consumers
+        # only ``import`` the fixture rather than installing as a plugin.
+        'pytest11': [
+            'neon_minerva_rabbit_mq = neon_minerva.integration.rabbit_mq',
+        ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setuptools.setup(
     install_requires=get_requirements("requirements.txt"),
     extras_require={"chatbots": get_requirements("chatbots.txt"),
                     "padatious": get_requirements("padatious.txt"),
-                    "rmq": get_requirements("rabbit_mq.txt")},
+                    "rmq": get_requirements("rabbit_mq.txt"),
+                    "test": get_requirements("test_requirements.txt")},
     entry_points={
         'console_scripts': ['minerva=neon_minerva.cli:neon_minerva_cli'],
         'pytest11': [

--- a/tests/test_rabbit_mq.py
+++ b/tests/test_rabbit_mq.py
@@ -1,0 +1,276 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import signal
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from neon_minerva.integration import rabbit_mq
+
+
+@pytest.fixture(autouse=True)
+def _clear_tracked_executors():
+    """Keep executor tracking list isolated across tests."""
+    rabbit_mq._ACTIVE_RMQ_EXECUTORS.clear()
+    yield
+    rabbit_mq._ACTIVE_RMQ_EXECUTORS.clear()
+
+
+class TestKillExecutorProcessgroup:
+    def test_no_process_is_noop(self):
+        executor = MagicMock(spec=[])
+        rabbit_mq._kill_executor_processgroup(executor)
+
+    def test_no_pid_is_noop(self):
+        executor = MagicMock()
+        executor.process = MagicMock()
+        executor.process.pid = None
+        with patch.object(rabbit_mq.os, "killpg") as killpg:
+            rabbit_mq._kill_executor_processgroup(executor)
+        killpg.assert_not_called()
+
+    def test_sends_sigkill_to_process_group(self):
+        executor = MagicMock()
+        executor.process.pid = 4242
+        with patch.object(rabbit_mq.os, "killpg") as killpg:
+            rabbit_mq._kill_executor_processgroup(executor)
+        killpg.assert_called_once_with(4242, signal.SIGKILL)
+
+    def test_oserror_is_swallowed(self):
+        executor = MagicMock()
+        executor.process.pid = 4242
+        with patch.object(rabbit_mq.os, "killpg", side_effect=OSError):
+            rabbit_mq._kill_executor_processgroup(executor)
+
+    def test_process_lookup_error_is_swallowed(self):
+        executor = MagicMock()
+        executor.process.pid = 4242
+        with patch.object(rabbit_mq.os, "killpg",
+                          side_effect=ProcessLookupError):
+            rabbit_mq._kill_executor_processgroup(executor)
+
+
+class TestStopExecutorQuietly:
+    def test_none_executor_is_noop(self):
+        rabbit_mq._stop_executor_quietly(None)
+
+    def test_stop_called_when_running(self):
+        executor = MagicMock()
+        executor.running.return_value = True
+        with patch.object(rabbit_mq, "_RMQ_STOP_TIMEOUT_SECONDS", 2):
+            rabbit_mq._stop_executor_quietly(executor)
+        executor.stop.assert_called_once_with()
+
+    def test_stop_skipped_when_not_running(self):
+        executor = MagicMock()
+        executor.running.return_value = False
+        with patch.object(rabbit_mq, "_RMQ_STOP_TIMEOUT_SECONDS", 2):
+            rabbit_mq._stop_executor_quietly(executor)
+        executor.stop.assert_not_called()
+
+    def test_stop_exception_is_swallowed(self):
+        executor = MagicMock()
+        executor.running.return_value = True
+        executor.stop.side_effect = RuntimeError("boom")
+        with patch.object(rabbit_mq, "_RMQ_STOP_TIMEOUT_SECONDS", 2):
+            rabbit_mq._stop_executor_quietly(executor)
+
+    def test_timeout_falls_back_to_killpg(self):
+        executor = MagicMock()
+        executor.running.return_value = True
+
+        def _hang_stop():
+            time.sleep(1.0)
+
+        executor.stop.side_effect = _hang_stop
+        with patch.object(rabbit_mq, "_RMQ_STOP_TIMEOUT_SECONDS", 0.05), \
+                patch.object(rabbit_mq, "_kill_executor_processgroup") as kill:
+            rabbit_mq._stop_executor_quietly(executor)
+        kill.assert_called_once_with(executor)
+
+
+class TestStopAllTrackedExecutors:
+    def test_stops_and_clears_tracked_executors(self):
+        first = MagicMock(name="first")
+        second = MagicMock(name="second")
+        rabbit_mq._ACTIVE_RMQ_EXECUTORS.extend([first, second])
+        with patch.object(rabbit_mq, "_stop_executor_quietly") as stop:
+            rabbit_mq._stop_all_tracked_executors()
+        assert stop.call_count == 2
+        stop.assert_any_call(first)
+        stop.assert_any_call(second)
+        assert rabbit_mq._ACTIVE_RMQ_EXECUTORS == []
+
+
+class TestArmForceExitWatchdog:
+    def test_spawns_daemon_watchdog_that_exits(self):
+        with patch.object(rabbit_mq.time, "sleep") as sleep, \
+                patch.object(rabbit_mq.os, "_exit") as force_exit, \
+                patch.object(rabbit_mq.sys.stderr, "write"), \
+                patch.object(rabbit_mq.sys.stderr, "flush"):
+            rabbit_mq._arm_force_exit_watchdog(0.01, exit_code=7)
+            # Allow daemon thread to run
+            deadline = time.time() + 2
+            while not force_exit.called and time.time() < deadline:
+                time.sleep(0.01)
+        sleep.assert_called_once_with(0.01)
+        force_exit.assert_called_once_with(7)
+
+
+class TestForceExitOnStalledShutdown:
+    def test_stops_tracked_and_arms_watchdog(self):
+        with patch.object(rabbit_mq, "_stop_all_tracked_executors") as stop, \
+                patch.object(rabbit_mq, "_arm_force_exit_watchdog") as arm:
+            rabbit_mq._force_exit_on_stalled_shutdown()
+        stop.assert_called_once_with()
+        arm.assert_called_once_with(
+            rabbit_mq._RMQ_FORCE_EXIT_GRACE_SECONDS, exit_code=0
+        )
+
+
+class TestPytestSessionfinish:
+    def test_stops_tracked_and_arms_watchdog_with_exit_status(self):
+        session = MagicMock()
+        with patch.object(rabbit_mq, "_stop_all_tracked_executors") as stop, \
+                patch.object(rabbit_mq, "_arm_force_exit_watchdog") as arm:
+            rabbit_mq.pytest_sessionfinish(session, exitstatus=3)
+        stop.assert_called_once_with()
+        arm.assert_called_once_with(
+            rabbit_mq._RMQ_FORCE_EXIT_GRACE_SECONDS, exit_code=3
+        )
+
+    def test_non_int_exitstatus_defaults_to_zero(self):
+        session = MagicMock()
+        with patch.object(rabbit_mq, "_stop_all_tracked_executors"), \
+                patch.object(rabbit_mq, "_arm_force_exit_watchdog") as arm:
+            rabbit_mq.pytest_sessionfinish(session, exitstatus="failed")
+        arm.assert_called_once_with(
+            rabbit_mq._RMQ_FORCE_EXIT_GRACE_SECONDS, exit_code=0
+        )
+
+
+def _rmq_instance_impl():
+    """Underlying fixture function (pytest forbids calling fixtures directly)."""
+    return rabbit_mq.rmq_instance._get_wrapped_function()
+
+
+class TestRmqInstanceMissingExtras:
+    def test_raises_when_optional_deps_missing(self):
+        request = MagicMock()
+        tmp_path_factory = MagicMock()
+        with patch.object(rabbit_mq, "_INITIALIZED", False):
+            with pytest.raises(ModuleNotFoundError, match="neon-minerva\\[rmq\\]"):
+                next(_rmq_instance_impl()(request, tmp_path_factory))
+
+
+class TestRmqInstanceFixtureUnit:
+    def test_starts_configures_and_tracks_executor(self, tmp_path_factory):
+        request = MagicMock()
+        request.fixturename = "rmq_instance"
+        request.cls = type("Dummy", (), {})()
+
+        executor = MagicMock()
+        executor.running.return_value = True
+        config = {
+            "ctl": "/usr/lib/rabbitmq/bin/rabbitmqctl",
+            "server": "/usr/lib/rabbitmq/bin/rabbitmq-server",
+            "port": None,
+            "distribution_port": None,
+            "plugindir": tmp_path_factory.mktemp("plugins"),
+            "logsdir": None,
+            "node": "rabbit@localhost",
+        }
+
+        with patch.object(rabbit_mq, "_INITIALIZED", True), \
+                patch.object(rabbit_mq, "get_config", return_value=config), \
+                patch.object(rabbit_mq, "get_port", side_effect=[5672, 25672]), \
+                patch.object(rabbit_mq, "RabbitMqExecutor",
+                             return_value=executor) as executor_cls, \
+                patch.dict(os.environ, {
+                    "TEST_RMQ_USERNAME": "ci_user",
+                    "TEST_RMQ_PASSWORD": "ci_pass",
+                    "TEST_RMQ_VHOSTS": "/a,/b",
+                }, clear=False), \
+                patch.object(rabbit_mq, "_stop_executor_quietly") as stop:
+            gen = _rmq_instance_impl()(request, tmp_path_factory)
+            yielded = next(gen)
+            assert yielded is executor
+            assert request.cls.rmq_instance is executor
+            assert executor in rabbit_mq._ACTIVE_RMQ_EXECUTORS
+            executor.start.assert_called_once_with()
+            executor.rabbitctl_output.assert_any_call(
+                "add_user", "ci_user", "ci_pass"
+            )
+            executor.rabbitctl_output.assert_any_call("add_vhost", "/a")
+            executor.rabbitctl_output.assert_any_call("add_vhost", "/b")
+            executor.rabbitctl_output.assert_any_call(
+                "set_permissions", "-p", "/a", "ci_user", ".*", ".*", ".*"
+            )
+            executor.rabbitctl_output.assert_any_call(
+                "set_permissions", "-p", "/b", "ci_user", ".*", ".*", ".*"
+            )
+            executor_cls.assert_called_once()
+
+            with pytest.raises(StopIteration):
+                next(gen)
+
+            stop.assert_called_once_with(executor)
+            assert executor not in rabbit_mq._ACTIVE_RMQ_EXECUTORS
+
+    def test_rejects_identical_ports(self, tmp_path_factory):
+        request = MagicMock()
+        request.fixturename = "rmq_instance"
+        config = {
+            "ctl": "ctl",
+            "server": "server",
+            "port": None,
+            "distribution_port": None,
+            "plugindir": tmp_path_factory.mktemp("plugins"),
+            "logsdir": None,
+            "node": "rabbit@localhost",
+        }
+        with patch.object(rabbit_mq, "_INITIALIZED", True), \
+                patch.object(rabbit_mq, "get_config", return_value=config), \
+                patch.object(rabbit_mq, "get_port", side_effect=[5672, 5672]):
+            with pytest.raises(AssertionError, match="can not be the same"):
+                next(_rmq_instance_impl()(request, tmp_path_factory))
+
+
+@pytest.mark.usefixtures("rmq_instance")
+class TestRmqInstanceIntegration:
+    """Live RabbitMQ subprocess smoke test for the class-scoped fixture."""
+
+    def test_broker_is_running_with_configured_user(self):
+        assert self.rmq_instance.running()
+        assert self.rmq_instance.port
+        # Default fixture credentials from rabbit_mq.py
+        users = self.rmq_instance.rabbitctl_output("list_users")
+        assert "test_user" in users
+        vhosts = self.rmq_instance.rabbitctl_output("list_vhosts")
+        assert "/test" in vhosts


### PR DESCRIPTION
# Description
Re-implements Pytest entrypoint for RMQ decorator
Re-implements safe teardown of RMQ test fixtures

# Issues
- Re-implements #33 which was somehow lost after one alpha release

# Other Notes
- Regression noted in https://github.com/NeonGeckoCom/neon-iris/pull/85
- Backwards-compat. tested via https://github.com/NeonGeckoCom/skill-alerts/actions/runs/30480647621